### PR TITLE
Fix re-requesting a review even if a member already approved

### DIFF
--- a/build/github.js
+++ b/build/github.js
@@ -91,6 +91,7 @@ function remove_reviewers(group) {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
+            reviewers: [],
             team_reviewers: teams,
         });
     });

--- a/build/github.js
+++ b/build/github.js
@@ -75,6 +75,26 @@ function assign_reviewers(group) {
         });
     });
 }
+function remove_reviewers(group) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const context = get_context();
+        const octokit = get_octokit();
+        if (context.payload.pull_request == undefined) {
+            throw 'Pull Request Number is Null';
+        }
+        const [teams_with_prefix,] = (0, partition_1.default)(group.members, member => member.startsWith('team:'));
+        const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+        if (teams.length === 0) {
+            return;
+        }
+        return octokit.pulls.removeRequestedReviewers({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            team_reviewers: teams,
+        });
+    });
+}
 function fetch_config() {
     return __awaiter(this, void 0, void 0, function* () {
         const context = get_context();
@@ -155,5 +175,6 @@ exports.default = {
     get_reviews,
     fetch_changed_files,
     assign_reviewers,
+    remove_reviewers,
     getTeamMembers
 };

--- a/build/index.js
+++ b/build/index.js
@@ -61,7 +61,6 @@ function run() {
         core.debug('Retrieving required group configurations...');
         let { affected: affectedGroups, unaffected: unaffectedGroups } = identifyGroupsByChangedFiles(config, yield github_1.default.fetch_changed_files());
         for (let groupName in affectedGroups) {
-            yield github_1.default.assign_reviewers(affectedGroups[groupName]);
             core.debug(` - Group: ${groupName}`);
             if (affectedGroups[groupName].required == undefined) {
                 core.warning(' - Group Required Count not specified, assuming 1 approver from group required.');
@@ -139,10 +138,12 @@ function run() {
                     core.info(`(${appCount}/${groupApprovalRequired})    ${groupNotApprovedStrings[unapproval]}`);
                 }
                 core.endGroup();
+                yield github_1.default.remove_reviewers(affectedGroups[groupName]);
             }
             else {
                 failed = true;
                 failedGroups.push(groupName);
+                yield github_1.default.assign_reviewers(affectedGroups[groupName]);
                 core.startGroup(`❌ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`);
                 let appCount = 0;
                 for (let approval in groupApprovedStrings) {

--- a/build/index.js
+++ b/build/index.js
@@ -95,6 +95,7 @@ function run() {
             let userName = review.user.login;
             let state = review.state;
             reviewerState[userName] = state;
+            core.info(`Found ${userName} with state ${state}`);
         }
         core.info("Processing reviews...");
         for (let userName in reviewerState) {
@@ -104,6 +105,7 @@ function run() {
                     for (let member in requirementMembers[group]) {
                         if (member == userName) {
                             requirementMembers[group][member] = true;
+                            core.info(`${userName} is a member of ${group} and has been approved`);
                         }
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -237,64 +237,65 @@ const github_1 = __importDefault(__nccwpck_require__(7295));
 function run() {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        core.info('Fetching configuration...');
+        core.info("Fetching configuration...");
         let config;
         try {
             config = yield github_1.default.fetch_config();
         }
         catch (error) {
             if (error.status === 404) {
-                core.warning('No configuration file is found in the base branch; terminating the process');
+                core.warning("No configuration file is found in the base branch; terminating the process");
             }
             throw error;
         }
-        core.debug("Config: ");
-        core.debug(JSON.stringify(config, null, '\t'));
-        core.info('Getting reviews...');
+        core.info("Config: ");
+        core.info(JSON.stringify(config, null, "\t"));
+        core.info("Getting reviews...");
         let reviews = yield github_1.default.get_reviews();
         let requirementCounts = {};
         let requirementMembers = {};
-        core.debug('Retrieving required group configurations...');
+        core.info("Retrieving required group configurations...");
         let { affected: affectedGroups, unaffected: unaffectedGroups } = identifyGroupsByChangedFiles(config, yield github_1.default.fetch_changed_files());
         for (let groupName in affectedGroups) {
-            core.debug(` - Group: ${groupName}`);
+            core.info(` - Group: ${groupName}`);
             if (affectedGroups[groupName].required == undefined) {
-                core.warning(' - Group Required Count not specified, assuming 1 approver from group required.');
+                core.warning(" - Group Required Count not specified, assuming 1 approver from group required.");
                 affectedGroups[groupName].required = 1;
             }
             else {
                 requirementCounts[groupName] = (_a = affectedGroups[groupName].required) !== null && _a !== void 0 ? _a : 1;
             }
             requirementMembers[groupName] = {};
-            core.debug(` - Requiring ${affectedGroups[groupName].required} of the following:`);
+            core.info(` - Requiring ${affectedGroups[groupName].required} of the following:`);
             for (let i in affectedGroups[groupName].members) {
                 let member = affectedGroups[groupName].members[i];
-                if (member.startsWith('team:')) { // extract teams.
+                if (member.startsWith("team:")) {
+                    // extract teams.
                     let teamMembers = yield github_1.default.getTeamMembers(member.substring(5));
                     for (let j in teamMembers) {
                         let teamMember = teamMembers[j];
                         requirementMembers[groupName][teamMember] = false;
-                        core.debug(`   - ${teamMember}`);
+                        core.info(`   - ${teamMember}`);
                     }
                 }
                 else {
                     requirementMembers[groupName][member] = false;
-                    core.debug(`   - ${member}`);
+                    core.info(`   - ${member}`);
                 }
             }
         }
         let reviewerState = {};
-        core.debug('Getting most recent review for each reviewer...');
+        core.info("Getting most recent review for each reviewer...");
         for (let i = 0; i < reviews.length; i++) {
             let review = reviews[i];
             let userName = review.user.login;
             let state = review.state;
             reviewerState[userName] = state;
         }
-        core.debug('Processing reviews...');
+        core.info("Processing reviews...");
         for (let userName in reviewerState) {
             let state = reviewerState[userName];
-            if (state == 'APPROVED') {
+            if (state == "APPROVED") {
                 for (let group in requirementMembers) {
                     for (let member in requirementMembers[group]) {
                         if (member == userName) {
@@ -306,13 +307,14 @@ function run() {
         }
         let failed = false;
         let failedGroups = [];
-        core.debug('Checking for required reviewers...');
+        core.info("Checking for required reviewers...");
         for (let groupName in requirementMembers) {
             let groupApprovalRequired = requirementCounts[groupName];
             let groupMemberApprovals = requirementMembers[groupName];
             let groupApprovalCount = 0;
             let groupNotApprovedStrings = [];
             let groupApprovedStrings = [];
+            core.info(`Checking group ${groupName}...`);
             for (let member in groupMemberApprovals) {
                 if (groupMemberApprovals[member]) {
                     groupApprovalCount++;
@@ -322,7 +324,6 @@ function run() {
                     groupNotApprovedStrings.push(member);
                 }
             }
-            // await github.explainStatus(group, groupMemberApprovals, groupCountRequired);
             if (groupApprovalCount >= groupApprovalRequired) {
                 //Enough Approvers
                 core.startGroup(`✅ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`);
@@ -352,7 +353,7 @@ function run() {
             }
         }
         if (failed) {
-            core.setFailed(`Need approval from these groups: ${failedGroups.join(', ')}`);
+            core.setFailed(`Need approval from these groups: ${failedGroups.join(", ")}`);
         }
     });
 }
@@ -366,7 +367,10 @@ function identifyGroupsByChangedFiles(config, changedFiles) {
             core.warning(`No specific path globs assigned for group ${groupName}, assuming global approval.`);
             affected[groupName] = group;
         }
-        else if (fileGlobs.filter(glob => minimatch.match(changedFiles, glob, { nonull: false, matchBase: true }).length > 0).length > 0) {
+        else if (fileGlobs.filter((glob) => minimatch.match(changedFiles, glob, {
+            nonull: false,
+            matchBase: true,
+        }).length > 0).length > 0) {
             affected[groupName] = group;
         }
         else {
@@ -379,7 +383,7 @@ module.exports = {
     run,
 };
 // Run the action if it's not running in an automated testing environment
-if (process.env.NODE_ENV !== 'automated-testing') {
+if (process.env.NODE_ENV !== "automated-testing") {
     run().catch((error) => {
         console.log(error);
         core.setFailed(error);

--- a/dist/index.js
+++ b/dist/index.js
@@ -291,6 +291,7 @@ function run() {
             let userName = review.user.login;
             let state = review.state;
             reviewerState[userName] = state;
+            core.info(`Found ${userName} with state ${state}`);
         }
         core.info("Processing reviews...");
         for (let userName in reviewerState) {
@@ -300,6 +301,7 @@ function run() {
                     for (let member in requirementMembers[group]) {
                         if (member == userName) {
                             requirementMembers[group][member] = true;
+                            core.info(`${userName} is a member of ${group} and has been approved`);
                         }
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -98,6 +98,7 @@ function remove_reviewers(group) {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
+            reviewers: [],
             team_reviewers: teams,
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "require-user-approval",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "require-user-approval",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "require-user-approval",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "require-user-approval",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "require-user-approval",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "GitHub Action that automatically checks if a set of required users have approved the pull request.",
   "main": "index.js",
   "scripts": {

--- a/src/github.ts
+++ b/src/github.ts
@@ -51,6 +51,29 @@ async function assign_reviewers(group: ConfigGroup) {
   });
 }
 
+async function remove_reviewers(group: ConfigGroup) {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  if (context.payload.pull_request == undefined) {
+    throw 'Pull Request Number is Null';
+  }
+
+  const [ teams_with_prefix,  ] = partition(group.members, member => member.startsWith('team:'));
+  const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+
+  if (teams.length === 0) {
+    return 
+  }
+
+  return octokit.pulls.removeRequestedReviewers({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+    team_reviewers: teams,
+  });
+}
+
 async function fetch_config(): Promise<Config> {
   const context = get_context();
   const octokit = get_octokit();
@@ -162,5 +185,6 @@ export default {
   get_reviews,
   fetch_changed_files,
   assign_reviewers,
+  remove_reviewers,
   getTeamMembers
 };

--- a/src/github.ts
+++ b/src/github.ts
@@ -70,6 +70,7 @@ async function remove_reviewers(group: ConfigGroup) {
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.payload.pull_request.number,
+    reviewers: [],
     team_reviewers: teams,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import * as core from '@actions/core';
-import { group } from 'console';
-import * as minimatch from 'minimatch';
-import { Config, ConfigGroup } from './config';
-import github from './github';
+import * as core from "@actions/core";
+import * as minimatch from "minimatch";
+import { Config, ConfigGroup } from "./config";
+import github from "./github";
 
 async function run() {
-  core.info('Fetching configuration...');
+  core.info("Fetching configuration...");
 
   let config;
 
@@ -13,39 +12,46 @@ async function run() {
     config = await github.fetch_config();
   } catch (error: any) {
     if (error.status === 404) {
-      core.warning('No configuration file is found in the base branch; terminating the process');
+      core.warning(
+        "No configuration file is found in the base branch; terminating the process"
+      );
     }
     throw error;
   }
 
-  core.debug("Config: ");
-  core.debug(JSON.stringify(config, null, '\t'));
+  core.info("Config: ");
+  core.info(JSON.stringify(config, null, "\t"));
 
-  core.info('Getting reviews...');
+  core.info("Getting reviews...");
   let reviews = await github.get_reviews();
 
   let requirementCounts: { [group: string]: number } = {};
   let requirementMembers: { [group: string]: { [user: string]: boolean } } = {};
-  core.debug('Retrieving required group configurations...');
+  core.info("Retrieving required group configurations...");
 
-  let { affected: affectedGroups, unaffected: unaffectedGroups } = identifyGroupsByChangedFiles(config, await github.fetch_changed_files());
+  let { affected: affectedGroups, unaffected: unaffectedGroups } =
+    identifyGroupsByChangedFiles(config, await github.fetch_changed_files());
 
   for (let groupName in affectedGroups) {
-    core.debug(` - Group: ${groupName}`);
+    core.info(` - Group: ${groupName}`);
     if (affectedGroups[groupName].required == undefined) {
-      core.warning(' - Group Required Count not specified, assuming 1 approver from group required.');
+      core.warning(
+        " - Group Required Count not specified, assuming 1 approver from group required."
+      );
       affectedGroups[groupName].required = 1;
     } else {
       requirementCounts[groupName] = affectedGroups[groupName].required ?? 1;
     }
     requirementMembers[groupName] = {};
-    core.debug(` - Requiring ${affectedGroups[groupName].required} of the following:`);
+    core.info(
+      ` - Requiring ${affectedGroups[groupName].required} of the following:`
+    );
     for (let i in affectedGroups[groupName].members) {
-
       let member = affectedGroups[groupName].members[i];
-      
-      if (member.startsWith('team:')) { // extract teams.
-        
+
+      if (member.startsWith("team:")) {
+        // extract teams.
+
         let teamMembers = await github.getTeamMembers(member.substring(5));
 
         for (let j in teamMembers) {
@@ -53,20 +59,19 @@ async function run() {
 
           requirementMembers[groupName][teamMember] = false;
 
-          core.debug(`   - ${teamMember}`);
+          core.info(`   - ${teamMember}`);
         }
-
       } else {
         requirementMembers[groupName][member] = false;
 
-        core.debug(`   - ${member}`);
+        core.info(`   - ${member}`);
       }
     }
   }
-  
-  let reviewerState: { [group:string] : string } = {};
 
-  core.debug('Getting most recent review for each reviewer...')
+  let reviewerState: { [group: string]: string } = {};
+
+  core.info("Getting most recent review for each reviewer...");
   for (let i = 0; i < reviews.length; i++) {
     let review = reviews[i];
     let userName = review.user.login;
@@ -74,12 +79,11 @@ async function run() {
     reviewerState[userName] = state;
   }
 
-  core.debug('Processing reviews...')
+  core.info("Processing reviews...");
 
   for (let userName in reviewerState) {
-    let state =  reviewerState[userName];
-    if (state == 'APPROVED')
-    {
+    let state = reviewerState[userName];
+    if (state == "APPROVED") {
       for (let group in requirementMembers) {
         for (let member in requirementMembers[group]) {
           if (member == userName) {
@@ -94,7 +98,7 @@ async function run() {
 
   let failedGroups: string[] = [];
 
-  core.debug('Checking for required reviewers...');
+  core.info("Checking for required reviewers...");
 
   for (let groupName in requirementMembers) {
     let groupApprovalRequired = requirementCounts[groupName];
@@ -102,24 +106,35 @@ async function run() {
     let groupApprovalCount = 0;
     let groupNotApprovedStrings: string[] = [];
     let groupApprovedStrings: string[] = [];
+
+    core.info(`Checking group ${groupName}...`);
+
     for (let member in groupMemberApprovals) {
       if (groupMemberApprovals[member]) {
         groupApprovalCount++;
         groupApprovedStrings.push(member);
-      }else {
+      } else {
         groupNotApprovedStrings.push(member);
       }
     }
-    // await github.explainStatus(group, groupMemberApprovals, groupCountRequired);
+
     if (groupApprovalCount >= groupApprovalRequired) {
       //Enough Approvers
-      core.startGroup(`✅ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`);
+      core.startGroup(
+        `✅ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`
+      );
       let appCount = 0;
       for (let approval in groupApprovedStrings) {
-        core.info(`(${++appCount}/${groupApprovalRequired}) ✅ ${groupApprovedStrings[approval]}`);
+        core.info(
+          `(${++appCount}/${groupApprovalRequired}) ✅ ${
+            groupApprovedStrings[approval]
+          }`
+        );
       }
       for (let unapproval in groupNotApprovedStrings) {
-        core.info(`(${appCount}/${groupApprovalRequired})    ${groupNotApprovedStrings[unapproval]}`);
+        core.info(
+          `(${appCount}/${groupApprovalRequired})    ${groupNotApprovedStrings[unapproval]}`
+        );
       }
       core.endGroup();
 
@@ -128,34 +143,58 @@ async function run() {
       failed = true;
       failedGroups.push(groupName);
       await github.assign_reviewers(affectedGroups[groupName]);
-      core.startGroup(`❌ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`);
+      core.startGroup(
+        `❌ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`
+      );
       let appCount = 0;
       for (let approval in groupApprovedStrings) {
-        core.info(`(${++appCount}/${groupApprovalRequired}) ✅ ${groupApprovedStrings[approval]}`);
+        core.info(
+          `(${++appCount}/${groupApprovalRequired}) ✅ ${
+            groupApprovedStrings[approval]
+          }`
+        );
       }
       for (let unapproval in groupNotApprovedStrings) {
-        core.info(`(${appCount}/${groupApprovalRequired}) ❌ ${groupNotApprovedStrings[unapproval]}`);
+        core.info(
+          `(${appCount}/${groupApprovalRequired}) ❌ ${groupNotApprovedStrings[unapproval]}`
+        );
       }
       core.endGroup();
     }
   }
   if (failed) {
-    core.setFailed(`Need approval from these groups: ${failedGroups.join(', ')}`);
+    core.setFailed(
+      `Need approval from these groups: ${failedGroups.join(", ")}`
+    );
   }
 }
 
-function identifyGroupsByChangedFiles(config: Config, changedFiles: string[]): { affected: { [name: string]:ConfigGroup }, unaffected: { [name: string]:ConfigGroup } } {
-  const affected: { [name: string]:ConfigGroup } = {};
-  const unaffected: { [name: string]:ConfigGroup } = {};
+function identifyGroupsByChangedFiles(
+  config: Config,
+  changedFiles: string[]
+): {
+  affected: { [name: string]: ConfigGroup };
+  unaffected: { [name: string]: ConfigGroup };
+} {
+  const affected: { [name: string]: ConfigGroup } = {};
+  const unaffected: { [name: string]: ConfigGroup } = {};
   for (let groupName in config.groups) {
     const group = config.groups[groupName];
     const fileGlobs = group.paths;
-    if (fileGlobs == null || fileGlobs == undefined || fileGlobs.length == 0)
-    {
-      core.warning(`No specific path globs assigned for group ${groupName}, assuming global approval.`);
+    if (fileGlobs == null || fileGlobs == undefined || fileGlobs.length == 0) {
+      core.warning(
+        `No specific path globs assigned for group ${groupName}, assuming global approval.`
+      );
       affected[groupName] = group;
-    }
-    else if (fileGlobs.filter(glob => minimatch.match(changedFiles, glob, {nonull: false,matchBase: true}).length > 0).length > 0){
+    } else if (
+      fileGlobs.filter(
+        (glob) =>
+          minimatch.match(changedFiles, glob, {
+            nonull: false,
+            matchBase: true,
+          }).length > 0
+      ).length > 0
+    ) {
       affected[groupName] = group;
     } else {
       unaffected[groupName] = group;
@@ -169,9 +208,9 @@ module.exports = {
 };
 
 // Run the action if it's not running in an automated testing environment
-if (process.env.NODE_ENV !== 'automated-testing') {
+if (process.env.NODE_ENV !== "automated-testing") {
   run().catch((error) => {
     console.log(error);
-    core.setFailed(error)
+    core.setFailed(error);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,8 @@ async function run() {
         core.info(`(${appCount}/${groupApprovalRequired})    ${groupNotApprovedStrings[unapproval]}`);
       }
       core.endGroup();
+
+      await github.remove_reviewers(affectedGroups[groupName]);
     } else {
       failed = true;
       failedGroups.push(groupName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ async function run() {
   let { affected: affectedGroups, unaffected: unaffectedGroups } = identifyGroupsByChangedFiles(config, await github.fetch_changed_files());
 
   for (let groupName in affectedGroups) {
-    await github.assign_reviewers(affectedGroups[groupName]);
     core.debug(` - Group: ${groupName}`);
     if (affectedGroups[groupName].required == undefined) {
       core.warning(' - Group Required Count not specified, assuming 1 approver from group required.');
@@ -126,6 +125,7 @@ async function run() {
     } else {
       failed = true;
       failedGroups.push(groupName);
+      await github.assign_reviewers(affectedGroups[groupName]);
       core.startGroup(`❌ ${groupName}: (${groupApprovalCount}/${groupApprovalRequired}) approval(s).`);
       let appCount = 0;
       for (let approval in groupApprovedStrings) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ async function run() {
     let userName = review.user.login;
     let state = review.state;
     reviewerState[userName] = state;
+    core.info(`Found ${userName} with state ${state}`);
   }
 
   core.info("Processing reviews...");
@@ -88,6 +89,9 @@ async function run() {
         for (let member in requirementMembers[group]) {
           if (member == userName) {
             requirementMembers[group][member] = true;
+            core.info(
+              `${userName} is a member of ${group} and has been approved`
+            );
           }
         }
       }


### PR DESCRIPTION
Previously: Every time the action ran it would request review from the user/team. This clears the past review essentially asking for another

Now: Only requests review if the user/team has not approved

closes #3